### PR TITLE
[인증/인가] 3주차 코드 리뷰 반영

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/src/main/java/team18/team18_be/auth/controller/AuthController.java
+++ b/src/main/java/team18/team18_be/auth/controller/AuthController.java
@@ -1,5 +1,10 @@
 package team18.team18_be.auth.controller;
 
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import java.net.URI;
 import org.springframework.http.HttpHeaders;
@@ -17,6 +22,7 @@ import team18.team18_be.auth.dto.response.OAuthJwtResponse;
 import team18.team18_be.auth.dto.response.UserTypeResponse;
 import team18.team18_be.auth.service.AuthService;
 
+@Tag(name = "인증/인가", description = "인증/인가 관련 API")
 @RestController
 @RequestMapping("/api")
 public class AuthController {
@@ -33,6 +39,7 @@ public class AuthController {
         this.authService = authService;
     }
 
+    @ApiResponse(responseCode = "301", description = "성공 (리다이렉트)", content = @Content(mediaType = "application/json", schema = @Schema(implementation = UserTypeResponse.class)))
     @PostMapping("/oauth")
     public ResponseEntity<UserTypeResponse> login(@RequestBody ClientIdRequest clientIdRequest) {
         OAuthJwtResponse oAuthJwtResponse = authService.getOAuthToken(clientIdRequest.code(),
@@ -49,6 +56,7 @@ public class AuthController {
         return new ResponseEntity<>(userTypeResponse, headers, HttpStatus.MOVED_PERMANENTLY);
     }
 
+    @ApiResponse(responseCode = "200", description = "성공")
     @PostMapping("/register")
     public ResponseEntity<Void> registerUserType(@RequestBody UserTypeRequest userTypeRequest,
         HttpServletRequest request) {

--- a/src/main/java/team18/team18_be/auth/controller/AuthController.java
+++ b/src/main/java/team18/team18_be/auth/controller/AuthController.java
@@ -3,7 +3,6 @@ package team18.team18_be.auth.controller;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import java.net.URI;

--- a/src/main/java/team18/team18_be/auth/controller/AuthController.java
+++ b/src/main/java/team18/team18_be/auth/controller/AuthController.java
@@ -25,7 +25,7 @@ public class AuthController {
 
     private static final String GOOGLE_AUTH_TOKEN_URL = "https://oauth2.googleapis.com/token";
 
-    private static final String GOOGLE_USER_INFO_URL = " https://www.googleapis.com/userinfo/v2/me";
+    private static final String GOOGLE_USER_INFO_URL = "https://www.googleapis.com/userinfo/v2/me";
 
     private final AuthService authService;
 

--- a/src/main/java/team18/team18_be/config/SwaggerConfig.java
+++ b/src/main/java/team18/team18_be/config/SwaggerConfig.java
@@ -1,0 +1,35 @@
+package team18.team18_be.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.security.SecurityScheme.In;
+import io.swagger.v3.oas.models.security.SecurityScheme.Type;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@OpenAPIDefinition(info = @Info(
+    title = "hire higher API",
+    description = "hire higher 서비스 플랫폼 API 제공",
+    version = "1.0.0"
+))
+public class SwaggerConfig {
+    @Bean
+    public OpenAPI api() {
+        SecurityScheme apiKey = new SecurityScheme()
+            .type(Type.APIKEY)
+            .in(In.HEADER)
+            .name("Authorization");
+
+        SecurityRequirement securityRequirement = new SecurityRequirement()
+            .addList("Bearer Token");
+
+        return new OpenAPI()
+            .components(new Components().addSecuritySchemes("Bearer Token", apiKey))
+            .addSecurityItem(securityRequirement);
+    }
+}


### PR DESCRIPTION
## 반영 내용

1. swaggerdoc 라이브러리 도입
2. swagger configuration 작성
3. controller에 swagger 명세 적용
4. auth controller에 문자열 상수 값 공백 오타 수정

<br/>
<br/>

## 회의했으면 하는 내용

1. swagger 라이브러리를 swaggerfox vs swaggerdoc : 알고 있는 바에 의하면 fox에 비해 docs의 업데이트가 훨씬 활발하게 이루어지고 있고, fox가 업데이트를 장기 중단했을 때 docs가 fox의 상위호환 느낌으로 발전해와서 현재에 와서는 docs가 더 많이 쓰이고 사용도 더 쉽다고 함. 그래서 개인적으로는 swaggerdoc을 도입하면 좋겠다고 생각하고 있는데, 어떤 라이브러리를 도입할지에 대한 협의가 필요할 것 같음
2. 원격에는 develop(최신) 브랜치로부터 4주차 weekly(weekly/4 등) 새로 만들고(기존 3주차 weekly는 그대로 냅두기), 포크 뜬 레포에 해당하는 로컬 프로젝트에서는 원격의 develop를 fetch로 가져와서 로컬 프로젝트의 develop에 rebase 후 이 develop으로부터 weekly/4를 분기한 뒤 작업 후 원격의 weekly/4에 PR 날리는 방식으로 생각하고 있는데 이게 적절한지?