### PR TITLE
[근로계약서] entity 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	implementation 'jakarta.validation:jakarta.validation-api:3.0.2'
 	implementation group: 'io.springfox', name: 'springfox-boot-starter', version: '3.0.0'
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
 }
 

--- a/src/main/java/team18/team18_be/contract/controller/ContractController.java
+++ b/src/main/java/team18/team18_be/contract/controller/ContractController.java
@@ -1,11 +1,13 @@
 package team18.team18_be.contract.controller;
 
+import io.swagger.annotations.ApiOperation;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import team18.team18_be.contract.dto.request.ContractRequest;
 import team18.team18_be.contract.dto.response.ContractResponse;
+import team18.team18_be.contract.service.ContractService;
 
 @RestController
 @RequestMapping("/api/contract")
@@ -16,25 +18,36 @@ public class ContractController {
         this.contractService = contractService;
     }
 
+    @ApiOperation(value = "근로계약서 등록 메서드 - 고용주 등록")
     @PostMapping
-    public ResponseEntity<Void> makeContract(@Valid @RequestBody ContractRequest request, @LoginMember Member member) {
-        contractService.makeContract(request, member);
+    public ResponseEntity<Void> makeContract(@Valid @RequestBody ContractRequest request, @LoginUser User user) {
+        contractService.makeContract(request, user);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
+    @ApiOperation(value = "근로계약서 등록 메서드 - 근로자 서명 등록")
+    @PostMapping("/employe")
+    public ResponseEntity<Void> makeContract(@LoginUser User user) {
+        contractService.makeContractEmployee(user);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @ApiOperation(value = "근로계약서 user id 별 조회 메서드")
     @GetMapping
-    public ResponseEntity<ContractResponse> getContract(@LoginMember Member member) {
-        return ResponseEntity.ok(contractService.getContract(member));
+    public ResponseEntity<ContractResponse> getContract(@LoginUser User user) {
+        return ResponseEntity.ok(contractService.getContract(user));
 
     }
 
+    @ApiOperation(value = "근로계약서 id별 pdf url 반환 메서드")
     @GetMapping("/{contractId}/download")
-    public ResponseEntity<byte[]> downloadContract(@PathVariable("contractId") Long id, @LoginMember Member member) {
-        return ResponseEntity.ok(contractService.downloadContract(id, member));
+    public ResponseEntity<String> downloadContract(@PathVariable("contractId") Long id, @LoginUser User user) {
+        return ResponseEntity.ok(contractService.downloadContract(id, user));
     }
 
+    @ApiOperation(value = "근로계약서 id별 image url 반환 메서드")
     @GetMapping("/{contractId}/preview")
-    public ResponseEntity<byte[]> previewContract(@PathVariable("contractId") Long id, @LoginMember Member member) {
-        return ResponseEntity.ok(contractService.previewContract(id, member));
+    public ResponseEntity<String> previewContract(@PathVariable("contractId") Long id, @LoginUser User user) {
+        return ResponseEntity.ok(contractService.previewContract(id, user));
     }
 }

--- a/src/main/java/team18/team18_be/contract/dto/request/ContractRequest.java
+++ b/src/main/java/team18/team18_be/contract/dto/request/ContractRequest.java
@@ -7,6 +7,7 @@ public record ContractRequest(
         String address,
         @Pattern(regexp = "^010-\\d{4}-\\d{4}$", message = "전화번호 형식이 아닙니다. 예) 010-0000-0000")
         String phoneNumber,
-        String contractPeriod
+        String contractPeriod,
+        Long employeeId
 ) {
 }

--- a/src/main/java/team18/team18_be/contract/dto/response/ContractResponse.java
+++ b/src/main/java/team18/team18_be/contract/dto/response/ContractResponse.java
@@ -1,10 +1,7 @@
 package team18.team18_be.contract.dto.response;
 
 public record ContractResponse(
-        Long id,
-        String companyName,
-        String address,
-        String phoneNumber,
-        String contractPeriod
+        Long contractId,
+        String companyName
 ) {
 }

--- a/src/main/java/team18/team18_be/contract/entity/Contract.java
+++ b/src/main/java/team18/team18_be/contract/entity/Contract.java
@@ -1,0 +1,26 @@
+package team18.team18_be.contract.entity;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.Pattern;
+
+@Entity(name = "contracts")
+public class Contract {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String companyName;
+    private String address;
+    private String phoneNumber;
+    private String contractPeriod;
+    private String imageFileName;
+    private String imageFileUrl;
+    private String pdfFileName;
+    private String pdfFileUrl;
+    @ManyToOne
+    @JoinColumn(name = "employerId")
+    private User employer;
+
+    @ManyToOne
+    @JoinColumn(name = "employeeId")
+    private User employee;
+}

--- a/src/main/java/team18/team18_be/contract/repository/ContractRepository.java
+++ b/src/main/java/team18/team18_be/contract/repository/ContractRepository.java
@@ -1,0 +1,7 @@
+package team18.team18_be.contract.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import team18.team18_be.contract.entity.Contract;
+
+public interface ContractRepository extends JpaRepository<Contract, Long> {
+}

--- a/src/main/java/team18/team18_be/contract/service/ContractService.java
+++ b/src/main/java/team18/team18_be/contract/service/ContractService.java
@@ -12,6 +12,7 @@ public class ContractService {
     public ContractService(ContractRepository contractRepository) {
         this.contractRepository = contractRepository;
     }
+
     public void makeContract(ContractRequest request, User user) {
     }
 

--- a/src/main/java/team18/team18_be/contract/service/ContractService.java
+++ b/src/main/java/team18/team18_be/contract/service/ContractService.java
@@ -1,0 +1,32 @@
+package team18.team18_be.contract.service;
+
+import org.springframework.stereotype.Service;
+import team18.team18_be.contract.dto.request.ContractRequest;
+import team18.team18_be.contract.dto.response.ContractResponse;
+import team18.team18_be.contract.repository.ContractRepository;
+
+@Service
+public class ContractService {
+    private final ContractRepository contractRepository;
+
+    public ContractService(ContractRepository contractRepository) {
+        this.contractRepository = contractRepository;
+    }
+    public void makeContract(ContractRequest request, User user) {
+    }
+
+    public void makeContractEmployee(User user) {
+    }
+
+    public ContractResponse getContract(User user) {
+        return new ContractResponse(1L, "");
+    }
+
+    public String downloadContract(Long id, User user) {
+        return "";
+    }
+
+    public String previewContract(Long id, User user) {
+        return "";
+    }
+}


### PR DESCRIPTION
- [x] contractController에 ApiOperation을 추가하여 api에 대한 설명을 추가했습니다.
- [x] controller에 근로계약서 등록 메서드를 고용주, 근로자 분리하여 생성하도록 수정했습니다.
- [x]  entity : 근로계약서는 근로자와 고용주가 서로 공유하는 형태로 존재하기에 의존관계 설정을 두 필드에 해줬습니다. 