### PR TITLE
[근로계약서] 변수명에 주석 추가

### DIFF
--- a/src/main/java/team18/team18_be/contract/dto/response/ContractFileResponse.java
+++ b/src/main/java/team18/team18_be/contract/dto/response/ContractFileResponse.java
@@ -1,7 +1,9 @@
 package team18.team18_be.contract.dto.response;
 
 public record ContractFileResponse(
+    // 한국어 파일 url
     String url,
+    // 베트남어 파일 url
     String urlV
 
 ) {


### PR DESCRIPTION
url, urlV에 대한 변수명이 명확하지 않아서 주석을 통해 베트남어인지 한국어인지 나타냄을 설명함