### PR TITLE
[근로계약서]연관관계 매핑 수정 및 두 번 호출될 경우 에러 처리

### DIFF
--- a/src/main/java/team18/team18_be/contract/entity/Contract.java
+++ b/src/main/java/team18/team18_be/contract/entity/Contract.java
@@ -5,7 +5,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
@@ -31,7 +31,7 @@ public class Contract {
   private String pdfFileUrl;
   private String imageFileUrlV;
   private String pdfFileUrlV;
-  @ManyToOne
+  @OneToOne
   @JoinColumn(name = "applyId")
   private Apply apply;
 

--- a/src/main/java/team18/team18_be/contract/service/ContractService.java
+++ b/src/main/java/team18/team18_be/contract/service/ContractService.java
@@ -3,6 +3,7 @@ package team18.team18_be.contract.service;
 import com.itextpdf.text.DocumentException;
 import jakarta.transaction.Transactional;
 import java.io.IOException;
+import java.util.Optional;
 import org.springframework.stereotype.Service;
 import team18.team18_be.apply.ApplyStatusEnum.ApplyStatus;
 import team18.team18_be.apply.entity.Apply;
@@ -15,6 +16,7 @@ import team18.team18_be.contract.dto.response.ContractFileResponse;
 import team18.team18_be.contract.dto.response.ContractResponse;
 import team18.team18_be.contract.entity.Contract;
 import team18.team18_be.contract.repository.ContractRepository;
+import team18.team18_be.exception.ContractAlreadyExistsException;
 import team18.team18_be.exception.NotFoundException;
 
 @Service
@@ -35,6 +37,12 @@ public class ContractService {
 
   public void handleEmployerContractCreation(ContractRequest request, User user)
       throws DocumentException, IOException {
+
+    Optional<Contract> optional = contractRepository.findByApplyId(request.applyId());
+
+    if (!optional.isEmpty()) {
+      throw new ContractAlreadyExistsException("이미 생성된 근로계약서입니다.");
+    }
 
     String dirName = "contracts";
     String fileName = user.getId() + "_" + request.applyId() + ".pdf";

--- a/src/main/java/team18/team18_be/exception/ContractAlreadyExistsException.java
+++ b/src/main/java/team18/team18_be/exception/ContractAlreadyExistsException.java
@@ -1,0 +1,12 @@
+package team18.team18_be.exception;
+
+public class ContractAlreadyExistsException extends RuntimeException {
+
+  public ContractAlreadyExistsException() {
+  }
+
+  public ContractAlreadyExistsException(String message) {
+    super(message);
+  }
+
+}

--- a/src/main/java/team18/team18_be/exception/GlobalExceptionHandler.java
+++ b/src/main/java/team18/team18_be/exception/GlobalExceptionHandler.java
@@ -87,4 +87,11 @@ public class GlobalExceptionHandler {
     ExceptionResponse exceptionResponse = new ExceptionResponse(e.getMessage());
     return new ResponseEntity<>(exceptionResponse, HttpStatus.BAD_REQUEST);
   }
+
+  @ExceptionHandler(value = ContractAlreadyExistsException.class)
+  public ResponseEntity<ExceptionResponse> handleContractAlreadyExistsException(
+      ContractAlreadyExistsException e) {
+    ExceptionResponse exceptionResponse = new ExceptionResponse(e.getMessage());
+    return new ResponseEntity<>(exceptionResponse, HttpStatus.BAD_REQUEST);
+  }
 }


### PR DESCRIPTION
ManyToOne으로 잘못 매핑한 것을 OneToOne으로 수정함
이미 생성한 근로계약서에 대한 요청이 올 경우 에러 처리함